### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/grpc-gen-ts.yaml
+++ b/.github/workflows/grpc-gen-ts.yaml
@@ -1,4 +1,7 @@
 name: grpc-gen-ts
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digi-lab-io/digi-lab-io-grpc-build-images/security/code-scanning/1](https://github.com/digi-lab-io/digi-lab-io-grpc-build-images/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow file, specifying the minimal permissions required for the workflow to function. Since the workflow checks out code and pushes a Docker image to GitHub Container Registry, it likely only needs `contents: read` (for code checkout) and `packages: write` (to push the image). The `contents: read` permission allows the workflow to read repository contents, and `packages: write` allows it to publish packages (such as Docker images) to GitHub Packages/Container Registry. The `permissions` block should be added at the workflow level (top-level, after `name:` and before `on:`) to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
