### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/grpc-gen-dart.yaml
+++ b/.github/workflows/grpc-gen-dart.yaml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - grpc-gen-dart/**/*
+permissions:
+  contents: read
+  packages: write
 jobs:
   build-grpc-gen-dart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/digi-lab-io/digi-lab-io-grpc-build-images/security/code-scanning/3](https://github.com/digi-lab-io/digi-lab-io-grpc-build-images/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are likely needed:
- `contents: read` for the `actions/checkout` step to read the repository contents.
- `packages: write` for the `docker/login-action` step to authenticate and push Docker images to the GitHub Container Registry.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
